### PR TITLE
improvement: add query filter by document type

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: neuroplastic
-version: 1.6.4
+version: 1.7.0
 crystal: 0.35.1
 license: MIT
 
@@ -19,4 +19,4 @@ development_dependencies:
     version: ~> 0.12
   rubber-soul:
     github: placeos/rubber-soul
-    version: ~> 1.12
+    version: ~> 1.15

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -60,6 +60,8 @@ def create_base
 end
 
 Spec.before_suite do
+  ::Log.setup("*", level: :debug)
+
   recreate_test_indices
   create_parent_child
   create_basic

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -19,13 +19,13 @@ end
 
 class Goat < AbstractBase
   attribute name : String
-  attribute teeth : Int32
-  attribute job : String
+  attribute teeth : Int32 = 0
+  attribute job : String = "being a goat"
 end
 
 class Child::Kid < AbstractBase
-  attribute age : Int32
-  attribute hoof_treatment : String
-  attribute visits : Array(String)
+  attribute age : Int32 = 0
+  attribute hoof_treatment : String = "oatmeal scrub"
+  attribute visits : Array(String) = [] of String
   belongs_to Goat
 end

--- a/src/neuroplastic/client.cr
+++ b/src/neuroplastic/client.cr
@@ -54,7 +54,6 @@ class Neuroplastic::Client
       :source,
       :stats,
       :stored_fields,
-      :stored_fields,
       :suggest_field,
       :suggest_mode,
       :suggest_size,

--- a/src/neuroplastic/elastic.cr
+++ b/src/neuroplastic/elastic.cr
@@ -6,7 +6,7 @@ class Neuroplastic::Elastic(T)
   SCORE  = ["_score"]
   ID     = "_id"
   SOURCE = "_source"
-  TYPE   = "type"
+  TYPE   = "_document_type"
 
   HITS  = "hits"
   TOTAL = "total"
@@ -31,8 +31,7 @@ class Neuroplastic::Elastic(T)
     builder = Query.new(params)
     builder.filter(filters) unless filters.nil?
 
-    # TODO: Filter all documents that don't have the correct document type
-    # builder.filter({TYPE => [elastic_document_name]})
+    builder.filter({TYPE => [elastic_document_name]})
 
     builder
   end
@@ -95,13 +94,7 @@ class Neuroplastic::Elastic(T)
   # Filters off results that do not match the document type.
   # Returns a collection of records pulled in from the db.
   private def get_records(result)
-    ids = result.dig?(HITS, HITS).try(&.as_a.compact_map { |hit|
-      doc_type = hit[SOURCE][TYPE].as_s
-      doc_type == elastic_document_name ? hit[ID].as_s : nil
-    })
-
-    # TODO: Filter by type query fails...
-    # ids = result.dig?(HITS, HITS).try(&.as_a.compact_map { |hit| hit[ID].as_s })
+    ids = result.dig?(HITS, HITS).try(&.as_a.compact_map { |hit| hit[ID].as_s })
 
     ids ? T.find_all(ids) : [] of T
   end


### PR DESCRIPTION
Aligning with changes made in PlaceOS/rubber-soul#12.
The key change is that queries are now filtered for documents with a matching document type.